### PR TITLE
feat: add QR code download functionality with improved UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>QR Code Generator</title>
     <link rel="stylesheet" href="style.css">
 </head>
+
 <body>
     <div class="container">
         <p>Enter your text or URL</p>
         <input type="text" placeholder="Text or URL" id="qrText">
+
         <div id="imgBox">
             <img src="" id="qrImg" alt="">
         </div>
+
         <button onclick="generateQRCode()">Generate QR Code</button>
+
+        <!-- NEW DOWNLOAD BUTTON -->
+        <button id="downloadBtn" disabled>Download QR Code</button>
     </div>
 
     <script src="script.js"></script>
 </body>
+
 </html>

--- a/script.js
+++ b/script.js
@@ -1,37 +1,49 @@
 let imgBox = document.getElementById("imgBox");
 let qrImg = document.getElementById("qrImg");
 let qrText = document.getElementById("qrText");
-let downloadBtn = document.getElementById("downloadBtn"); // NEW
+let downloadBtn = document.getElementById("downloadBtn");
 
 function generateQRCode() {
   if (qrText.value.length > 0) {
     qrImg.src =
       "https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=" +
-      encodeURIComponent(qrText.value); // safer encoding
+      encodeURIComponent(qrText.value);
 
     imgBox.classList.add("show-img");
 
-    // Enable download button after QR loads
     qrImg.onload = function () {
       downloadBtn.disabled = false;
     };
   } else {
     qrText.classList.add("error");
-    downloadBtn.disabled = true; // keep disabled if invalid
+    downloadBtn.disabled = true;
+
     setTimeout(() => {
       qrText.classList.remove("error");
     }, 1000);
   }
 }
 
-// Download QR Functionality
-downloadBtn.addEventListener("click", function () {
+// FIXED Download Logic (No New Tab Issue)
+downloadBtn.addEventListener("click", async function () {
   if (!qrImg.src) return;
 
-  const link = document.createElement("a");
-  link.href = qrImg.src;
-  link.download = "qr-code.png";
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  try {
+    const response = await fetch(qrImg.src);
+    const blob = await response.blob();
+
+    const blobUrl = window.URL.createObjectURL(blob);
+
+    const link = document.createElement("a");
+    link.href = blobUrl;
+    link.download = "qr-code.png";
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    window.URL.revokeObjectURL(blobUrl);
+  } catch (error) {
+    alert("Download failed. Please try again.");
+  }
 });

--- a/script.js
+++ b/script.js
@@ -1,19 +1,37 @@
 let imgBox = document.getElementById("imgBox");
 let qrImg = document.getElementById("qrImg");
 let qrText = document.getElementById("qrText");
+let downloadBtn = document.getElementById("downloadBtn"); // NEW
 
 function generateQRCode() {
   if (qrText.value.length > 0) {
     qrImg.src =
       "https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=" +
-      qrText.value;
-    imgBox.classList.add("show-img");
-  }
+      encodeURIComponent(qrText.value); // safer encoding
 
-  else{
-    qrText.classList.add('error')
+    imgBox.classList.add("show-img");
+
+    // Enable download button after QR loads
+    qrImg.onload = function () {
+      downloadBtn.disabled = false;
+    };
+  } else {
+    qrText.classList.add("error");
+    downloadBtn.disabled = true; // keep disabled if invalid
     setTimeout(() => {
-        qrText.classList.remove('error')
+      qrText.classList.remove("error");
     }, 1000);
   }
 }
+
+// Download QR Functionality
+downloadBtn.addEventListener("click", function () {
+  if (!qrImg.src) return;
+
+  const link = document.createElement("a");
+  link.href = qrImg.src;
+  link.download = "qr-code.png";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+});

--- a/style.css
+++ b/style.css
@@ -1,14 +1,15 @@
-*{
+* {
     margin: 0;
     padding: 0;
     font-family: 'Poppins', sans-serif;
     box-sizing: border-box;
 }
-body{
+
+body {
     background: #B38BAF;
 }
 
-.container{
+.container {
     width: 400px;
     padding: 25px 35px;
     position: absolute;
@@ -18,12 +19,14 @@ body{
     background: #fff;
     border-radius: 10px;
 }
-.container p{
+
+.container p {
     font-weight: 600;
     font-size: 15px;
     margin-bottom: 8px;
 }
-.container input{
+
+.container input {
     width: 100%;
     height: 50px;
     border: 1px solid #6C436C;
@@ -31,8 +34,14 @@ body{
     padding: 10px;
     margin: 10px 0 20px;
     border-radius: 5px;
+    transition: border 0.3s ease;
 }
-.container button{
+
+.container input:focus {
+    border: 1px solid #7B547A;
+}
+
+.container button {
     width: 100%;
     height: 50px;
     background: #7B547A;
@@ -42,42 +51,65 @@ body{
     border-radius: 5px;
     box-shadow: 0 10px 10px rgba(0, 0, 0, 0.3);
     cursor: pointer;
-    margin: 20px 0;
+    margin: 15px 0;
     font-weight: 500;
+    transition: 0.3s ease;
 }
-#imgBox{
+
+.container button:hover {
+    opacity: 0.9;
+}
+
+/* Disabled download button styling */
+.container button:disabled {
+    background: #c7b5c7;
+    cursor: not-allowed;
+    box-shadow: none;
+    opacity: 0.7;
+}
+
+#imgBox {
     width: 200px;
     border-radius: 5px;
     max-height: 0;
     overflow: hidden;
-    transition: max-height 0.5s;
+    transition: max-height 0.5s ease;
 }
-#imgBox img{
+
+#imgBox img {
     width: 100%;
     padding: 10px;
 }
-#imgBox.show-img{
+
+#imgBox.show-img {
     max-height: 300px;
     margin: 10px auto;
     border: 1px solid #d1d1d1;
 }
-.error{
+
+/* Error animation */
+.error {
     animation: shake 0.1s linear 5;
 }
-@keyframes shake{
-    0%{
+
+@keyframes shake {
+    0% {
         transform: translateX(0);
     }
-    25%{
+
+    25% {
         transform: translateX(-2px);
     }
-    50%{
+
+    50% {
         transform: translateX(0);
     }
-    75%{
+
+    75% {
         transform: translateX(2px);
     }
-    100%{
+
+    100% {
         transform: translateX(0);
     }
 }


### PR DESCRIPTION
## Description
This PR adds a download button allowing users to save generated QR codes locally as PNG files.

## Changes Made
<img width="1470" height="956" alt="Screenshot 2026-03-02 at 8 47 38 AM" src="https://github.com/user-attachments/assets/04e4a771-64e5-4d18-8bcc-6284bcc0adfd" />
<img width="695" height="870" alt="Screenshot 2026-03-02 at 8 59 21 AM" src="https://github.com/user-attachments/assets/388b01aa-a384-49be-b4c2-bc78c6f5973c" />


- Added Download QR Code button
- Enabled button only after QR generation
- Improved input encoding using encodeURIComponent
- Added disabled button styling for better UX

## Why This Is Needed
Improves usability by allowing users to easily save generated QR codes.


