### PR TITLE
feat: add QR code history feature using localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
         <p>Upload Logo (Optional)</p>
         <input type="file" id="logoUpload" accept="image/*">
 
+        <!-- QR PREVIEW -->
         <div id="imgBox">
-            <!-- canvas replaces img so we can draw logo -->
             <canvas id="qrCanvas"></canvas>
         </div>
 
@@ -40,6 +40,16 @@
 
         <!-- DOWNLOAD BUTTON -->
         <button id="downloadBtn" disabled>Download QR Code</button>
+
+
+        <!-- QR HISTORY SECTION -->
+        <div id="historyContainer">
+
+            <p class="historyTitle">Recent QR Codes</p>
+
+            <ul id="historyList"></ul>
+
+        </div>
 
     </div>
 

--- a/script.js
+++ b/script.js
@@ -8,8 +8,13 @@ let qrColor = document.getElementById("qrColor");
 let qrBgColor = document.getElementById("qrBgColor");
 let logoUpload = document.getElementById("logoUpload");
 
+let historyList = document.getElementById("historyList");
+
 let canvas = document.getElementById("qrCanvas");
 let ctx = canvas.getContext("2d");
+
+// Load QR history
+let qrHistory = JSON.parse(localStorage.getItem("qrHistory")) || [];
 
 
 // Show slider value
@@ -18,6 +23,46 @@ sizeValue.innerText = qrSize.value;
 qrSize.addEventListener("input", () => {
   sizeValue.innerText = qrSize.value;
 });
+
+
+// Save history
+function saveHistory(value) {
+
+  if (!value) return;
+
+  qrHistory.unshift(value);
+
+  // Remove duplicates + keep last 10
+  qrHistory = [...new Set(qrHistory)].slice(0,10);
+
+  localStorage.setItem("qrHistory", JSON.stringify(qrHistory));
+
+  renderHistory();
+}
+
+
+// Render history UI
+function renderHistory(){
+
+  historyList.innerHTML = "";
+
+  qrHistory.forEach(item => {
+
+    const li = document.createElement("li");
+
+    li.textContent = item;
+
+    li.style.cursor = "pointer";
+
+    li.onclick = () => {
+      qrText.value = item;
+      generateQRCode();
+    };
+
+    historyList.appendChild(li);
+  });
+
+}
 
 
 function generateQRCode() {
@@ -78,6 +123,9 @@ function generateQRCode() {
     imgBox.classList.add("show-img");
     downloadBtn.disabled = false;
 
+    // Save QR to history
+    saveHistory(qrText.value);
+
   };
 
 }
@@ -94,3 +142,7 @@ downloadBtn.addEventListener("click", function () {
   link.click();
 
 });
+
+
+// Load history when page loads
+renderHistory();

--- a/style.css
+++ b/style.css
@@ -155,3 +155,44 @@ body {
     font-size: 17px;
     color: #7B547A;
 }
+/* QR History Section */
+
+#historyContainer {
+    width: 100%;
+    margin-top: 20px;
+    padding: 15px;
+    background: #f6f3f8;
+    border-radius: 10px;
+    border: 1px solid #e3dbe8;
+}
+
+.historyTitle {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 10px;
+    color: #6C436C;
+    text-align: center;
+}
+
+#historyList {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#historyList li {
+    background: white;
+    border: 1px solid #ddd;
+    padding: 8px 10px;
+    border-radius: 6px;
+    margin-bottom: 6px;
+    font-size: 14px;
+    transition: all 0.2s ease;
+}
+
+#historyList li:hover {
+    background: #7B547A;
+    color: white;
+    cursor: pointer;
+    transform: scale(1.02);
+}


### PR DESCRIPTION

This PR introduces a "QR Code History feature" that allows users to view and reuse recently generated QR codes.

Currently, the application generates QR codes but does not store previously generated inputs. This feature improves usability by allowing users to quickly regenerate recently created QR codes.

## Features Added

- Stores recently generated QR inputs using **localStorage**
- Displays the **last 10 generated QR codes**
- Clicking a history item automatically regenerates the QR code
- History persists even after page refresh
- Added styling for the history section to match the existing UI theme

## Implementation Details

- Added a **Recent QR Codes** section in `index.html`
- Implemented history logic in `script.js`
- Stored history using `localStorage`
- Added CSS styling for the history section in `style.css`

## Files Modified

- `index.html`
- `script.js`
- `style.css`

## Result

Users can now easily access and reuse recently generated QR codes, improving the overall user experience.

## In this screenshot, yiu can see that the history section is appearing at the bottom:

<img width="980" height="852" alt="Screenshot 2026-03-13 at 12 50 30 AM" src="https://github.com/user-attachments/assets/5fd0f05c-00b8-42f5-a701-dbebc4dba18e" />
